### PR TITLE
get dynamo db table name from environment table

### DIFF
--- a/get_item.py
+++ b/get_item.py
@@ -2,7 +2,7 @@ import json
 import boto3
 import os 
 
-db_name = os.environ.get('db_name')
+db_name = os.environ.get('my_db_name')
 dynamodb = boto3.resource('dynamodb')
 table = dynamodb.Table('db_name')
 

--- a/get_item.py
+++ b/get_item.py
@@ -4,7 +4,7 @@ import os
 
 db_name = os.environ.get('my_db_name')
 dynamodb = boto3.resource('dynamodb')
-table = dynamodb.Table('db_name')
+table = dynamodb.Table(db_name)
 
 def lambda_handler(event, context):
     items_id = event.get('items_id')


### PR DESCRIPTION
I'm getting an error when I test the function :"resource not found" and I'm not sure why. I verified if it has permissions to access the dynamodb table and made sure the name is correct + if they are in the same region but I can't figure out  why the error is coming up.